### PR TITLE
Make fstring.py work on Python 3.

### DIFF
--- a/fstring.py
+++ b/fstring.py
@@ -42,7 +42,7 @@ class fstring(str):
         fstringified = self.origin
         for match in self.INDICATOR_PATTERN.findall(fstringified):
             indicator = match[1:-1]
-            parsed_expression = filter(None, re.split(r"(\w+)", indicator))[0]
+            parsed_expression = next(iter(filter(None, re.split(r"(\w+)", indicator))))
 
             frame = self._var(parsed_expression)
             value = eval(indicator, None, frame)


### PR DESCRIPTION
Somewhat ironic, but it eases the 2.7 -> 3 transition to do so.

Also, it allows it to support Python 3.5 and lower which don't have native f-strings.