### PR TITLE
 replace "astroid.decorators" with "cached_property" and fix dependencies

### DIFF
--- a/fstring/fstring.py
+++ b/fstring/fstring.py
@@ -4,7 +4,7 @@ import inspect
 from platform import python_version
 
 from six import text_type
-from astroid.decorators import cachedproperty
+from cached_property import cached_property
 
 # pylint: disable=invalid-name,missing-docstring
 def python2_cmp(a, b):
@@ -40,7 +40,7 @@ class fstring(text_type):  # pylint: disable=invalid-name
         super(fstring, self).__init__()
         self.origin = text_type(origin)
 
-    @cachedproperty
+    @cached_property
     def cached_origin(self):
         return self.fstringify()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,7 @@
 [metadata]
 description-file = README.md
+
+[options]
+install_requires =
+  cached_property
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,5 @@ description-file = README.md
 [options]
 install_requires =
   cached_property
+  six
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='elkissdan@gmail.com',
     license='MIT',
     zip_safe=False,
-    url='https://github.com/d-kiss/fstring',
+    url='https://github.com/rinslow/fstring',
     keywords=['string', 'fstring', 'formatting', 'inline', 'evaluation'],
     classifiers=[
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This pull request does multiple things but as each commit is trivial I decided just to do a single request. Let me know if you prefer separated pull requests.

1.  replace "astroid.decorators" with "cached_property": This was my main gripe as "astroid" was not a proper dependency and then I was annoyed I could not use the latest version so I just went for a self-contained library. This also fixes #16.
1. The rest is simple metadata fixes, including the declaration of "six" as dependency as well as fixing issue #14.

Additional annoyances I'd like to fix in follow-up changes:
- python setup.py test does not run any tests (simplest way to fix this is adding a `__init__.py` in the `test` folder)
- license mismatch: setup.py says MIT but the `LICENSE` file contains the WTFPL (I like MIT more but whatever you decide, just be consistent)
- maybe: move all metadata to `setup.cfg` (+ `VERSION.txt`) so they are discoverable without running `setup.py`.